### PR TITLE
Add subscription queries and mutations

### DIFF
--- a/app/graphql/shopify_graphql/app_subscription_fields.rb
+++ b/app/graphql/shopify_graphql/app_subscription_fields.rb
@@ -1,0 +1,68 @@
+module ShopifyGraphql
+  class AppSubscriptionFields
+    FRAGMENT = <<~GRAPHQL
+      fragment AppSubscriptionFields on AppSubscription {
+        id
+        name
+        status
+        createdAt
+        trialDays
+        currentPeriodEnd
+        test
+        lineItems {
+          id
+          plan {
+            pricingDetails {
+              __typename
+              ... on AppRecurringPricing {
+                price {
+                  amount
+                }
+                interval
+              }
+              ... on AppUsagePricing {
+                balanceUsed {
+                  amount
+                }
+                cappedAmount {
+                  amount
+                }
+                interval
+                terms
+              }
+            }
+          }
+        }
+      }
+    GRAPHQL
+
+    def self.parse(data)
+      recurring_line_item = data.lineItems.find do |line_item|
+        line_item.plan.pricingDetails.__typename == "AppRecurringPricing"
+      end
+      recurring_pricing = recurring_line_item&.plan&.pricingDetails
+      usage_line_item = data.lineItems.find do |line_item|
+        line_item.plan.pricingDetails.__typename == "AppUsagePricing"
+      end
+      usage_pricing = usage_line_item&.plan&.pricingDetails
+
+      OpenStruct.new(
+        id: data.id,
+        name: data.name,
+        status: data.status,
+        created_at: data.createdAt && Time.parse(data.createdAt),
+        trial_days: data.trialDays,
+        current_period_end: data.currentPeriodEnd && Time.parse(data.currentPeriodEnd),
+        test: data.test,
+        recurring_line_item_id: recurring_line_item&.id,
+        recurring_price: recurring_pricing&.price&.amount&.to_d,
+        recurring_interval: recurring_pricing&.interval,
+        usage_line_item_id: usage_line_item&.id,
+        usage_balance: usage_pricing&.balanceUsed&.amount&.to_d,
+        usage_capped_amount: usage_pricing&.cappedAmount&.amount&.to_d,
+        usage_interval: usage_pricing&.interval,
+        usage_terms: usage_pricing&.terms
+      )
+    end
+  end
+end

--- a/app/graphql/shopify_graphql/create_recurring_subscription.rb
+++ b/app/graphql/shopify_graphql/create_recurring_subscription.rb
@@ -1,0 +1,64 @@
+module ShopifyGraphql
+  class CreateRecurringSubscription
+    include Mutation
+
+    MUTATION = <<~GRAPHQL
+      #{AppSubscriptionFields::FRAGMENT}
+
+      mutation appSubscriptionCreate(
+        $name: String!,
+        $lineItems: [AppSubscriptionLineItemInput!]!,
+        $returnUrl: URL!,
+        $trialDays: Int,
+        $test: Boolean
+      ) {
+        appSubscriptionCreate(
+          name: $name,
+          lineItems: $lineItems,
+          returnUrl: $returnUrl,
+          trialDays: $trialDays,
+          test: $test
+        ) {
+          appSubscription {
+            ... AppSubscriptionFields
+          }
+          confirmationUrl
+          userErrors {
+            field
+            message
+          }
+        }
+      }
+    GRAPHQL
+
+    def call(name:, price:, return_url:, trial_days: nil, test: nil, interval: :monthly)
+      payload = {name: name, returnUrl: return_url}
+      plan_interval = interval == :monthly ? "EVERY_30_DAYS" : "ANNUAL"
+      payload[:lineItems] = [{
+        plan: {
+          appRecurringPricingDetails: {
+            price: {amount: price, currencyCode: "USD"},
+            interval: plan_interval
+          }
+        }
+      }]
+      payload[:trialDays] = trial_days if trial_days
+      payload[:test] = test if test
+
+      response = execute(MUTATION, **payload)
+      response.data = response.data.appSubscriptionCreate
+      handle_user_errors(response.data)
+      response.data = parse_data(response.data)
+      response
+    end
+
+    private
+
+    def parse_data(data)
+      OpenStruct.new(
+        subscription: AppSubscriptionFields.parse(data.appSubscription),
+        confirmation_url: data.confirmationUrl
+      )
+    end
+  end
+end

--- a/app/graphql/shopify_graphql/create_usage_subscription.rb
+++ b/app/graphql/shopify_graphql/create_usage_subscription.rb
@@ -1,0 +1,62 @@
+module ShopifyGraphql
+  class CreateUsageSubscription
+    include Mutation
+
+    MUTATION = <<~GRAPHQL
+      #{AppSubscriptionFields::FRAGMENT}
+
+      mutation appSubscriptionCreate(
+        $name: String!,
+        $returnUrl: URL!,
+        $test: Boolean
+        $lineItems: [AppSubscriptionLineItemInput!]!,
+      ) {
+        appSubscriptionCreate(
+          name: $name,
+          returnUrl: $returnUrl,
+          test: $test
+          lineItems: $lineItems,
+        ) {
+          appSubscription {
+            ... AppSubscriptionFields
+          }
+          confirmationUrl
+          userErrors {
+            field
+            message
+          }
+        }
+      }
+    GRAPHQL
+
+    def call(name:, return_url:, terms:, capped_amount:, test: false)
+      response = execute(
+        MUTATION,
+        name: name,
+        returnUrl: return_url,
+        test: test,
+        lineItems: [{
+          plan: {
+            appUsagePricingDetails: {
+              terms: terms,
+              cappedAmount: {amount: capped_amount, currencyCode: "USD"}
+            }
+          }
+        }]
+      )
+      response.data = response.data.appSubscriptionCreate
+      handle_user_errors(response.data)
+      response.data = parse_data(response.data)
+      response
+    end
+
+    private
+
+    def parse_data(data)
+      OpenStruct.new(
+        subscription: AppSubscriptionFields.parse(data.appSubscription),
+        confirmation_url: data.confirmationUrl
+      )
+    end
+  end
+end

--- a/app/graphql/shopify_graphql/get_app_subscription.rb
+++ b/app/graphql/shopify_graphql/get_app_subscription.rb
@@ -1,0 +1,21 @@
+module ShopifyGraphql
+  class GetAppSubscription
+    include Query
+
+    QUERY = <<~GRAPHQL
+      #{AppSubscriptionFields::FRAGMENT}
+
+      query($id: ID!) {
+        node(id: $id) {
+          ... AppSubscriptionFields
+        }
+      }
+    GRAPHQL
+
+    def call(id:)
+      response = execute(QUERY, id: id)
+      response.data = AppSubscriptionFields.parse(response.data.node)
+      response
+    end
+  end
+end

--- a/bin/rails
+++ b/bin/rails
@@ -1,0 +1,14 @@
+#!/usr/bin/env ruby
+# This command will automatically be run when you run "rails" with Rails gems
+# installed from the root of your application.
+
+ENGINE_ROOT = File.expand_path('..', __dir__)
+ENGINE_PATH = File.expand_path('../lib/shopify_graphql/engine', __dir__)
+APP_PATH = File.expand_path('../test/dummy/config/application', __dir__)
+
+# Set up gems listed in the Gemfile.
+ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
+require "bundler/setup" if File.exist?(ENV["BUNDLE_GEMFILE"])
+
+require "rails/all"
+require "rails/engine/commands"

--- a/test/fixtures/mutations/create_recurring_subscription.json
+++ b/test/fixtures/mutations/create_recurring_subscription.json
@@ -1,0 +1,42 @@
+{
+  "data": {
+    "appSubscriptionCreate": {
+      "appSubscription": {
+        "id": "gid://shopify/AppSubscription/22229811283",
+        "name": "Standard Plan",
+        "status": "PENDING",
+        "createdAt": "2022-02-11T06:04:04Z",
+        "trialDays": 3,
+        "currentPeriodEnd": null,
+        "test": true,
+        "lineItems": [
+          {
+            "id": "gid://shopify/AppSubscriptionLineItem/22229811283?v=1&index=0",
+            "plan": {
+              "pricingDetails": {
+                "__typename": "AppRecurringPricing",
+                "price": {
+                  "amount": "29.99"
+                },
+                "interval": "ANNUAL"
+              }
+            }
+          }
+        ]
+      },
+      "confirmationUrl": "https://graphql-gem-test.myshopify.com/admin/charges/6482851/22229811283/RecurringApplicationCharge/confirm_recurring_application_charge?signature=BAh7BzoHaWRsKwhTAAAtBQA6EmF1dG9fYWN0aXZhdGVU--736eb13604129eb23a9aab793bd85fa9efcb7058",
+      "userErrors": []
+    }
+  },
+  "extensions": {
+    "cost": {
+      "requestedQueryCost": 13,
+      "actualQueryCost": 13,
+      "throttleStatus": {
+        "maximumAvailable": 1000,
+        "currentlyAvailable": 987,
+        "restoreRate": 50
+      }
+    }
+  }
+}

--- a/test/fixtures/mutations/create_usage_subscription.json
+++ b/test/fixtures/mutations/create_usage_subscription.json
@@ -1,0 +1,46 @@
+{
+  "data": {
+    "appSubscriptionCreate": {
+      "appSubscription": {
+        "id": "gid://shopify/AppSubscription/22229909587",
+        "name": "Standard Plan",
+        "status": "PENDING",
+        "createdAt": "2022-02-11T06:43:51Z",
+        "trialDays": 0,
+        "currentPeriodEnd": null,
+        "test": true,
+        "lineItems": [
+          {
+            "id": "gid://shopify/AppSubscriptionLineItem/22229909587?v=1&index=0",
+            "plan": {
+              "pricingDetails": {
+                "__typename": "AppUsagePricing",
+                "balanceUsed": {
+                  "amount": "0.0"
+                },
+                "cappedAmount": {
+                  "amount": "50.0"
+                },
+                "interval": "EVERY_30_DAYS",
+                "terms": "Terms Description"
+              }
+            }
+          }
+        ]
+      },
+      "confirmationUrl": "https://graphql-gem-test.myshopify.com/admin/charges/6482851/22229909587/RecurringApplicationCharge/confirm_recurring_application_charge?signature=BAh7BzoHaWRsKwhTgAEtBQA6EmF1dG9fYWN0aXZhdGVU--c0a6dff794d291fddd98f75c04f73c8d6d29ac79",
+      "userErrors": []
+    }
+  },
+  "extensions": {
+    "cost": {
+      "requestedQueryCost": 13,
+      "actualQueryCost": 13,
+      "throttleStatus": {
+        "maximumAvailable": 1000,
+        "currentlyAvailable": 987,
+        "restoreRate": 50
+      }
+    }
+  }
+}

--- a/test/fixtures/queries/app_subscription.json
+++ b/test/fixtures/queries/app_subscription.json
@@ -1,0 +1,38 @@
+{
+  "data": {
+    "node": {
+      "id": "gid://shopify/AppSubscription/22229811283",
+      "name": "Standard Plan",
+      "status": "PENDING",
+      "createdAt": "2022-02-11T06:04:04Z",
+      "trialDays": 3,
+      "currentPeriodEnd": null,
+      "test": true,
+      "lineItems": [
+        {
+          "id": "gid://shopify/AppSubscriptionLineItem/22229811283?v=1&index=0",
+          "plan": {
+            "pricingDetails": {
+              "__typename": "AppRecurringPricing",
+              "price": {
+                "amount": "29.99"
+              },
+              "interval": "ANNUAL"
+            }
+          }
+        }
+      ]
+    }
+  },
+  "extensions": {
+    "cost": {
+      "requestedQueryCost": 4,
+      "actualQueryCost": 4,
+      "throttleStatus": {
+        "maximumAvailable": 1000,
+        "currentlyAvailable": 996,
+        "restoreRate": 50
+      }
+    }
+  }
+}

--- a/test/graphql/shopify_graphql/create_recurring_subscription_test.rb
+++ b/test/graphql/shopify_graphql/create_recurring_subscription_test.rb
@@ -1,0 +1,45 @@
+require "test_helper"
+
+class CreateRecurringSubscriptionTest < ActiveSupport::TestCase
+  test "creates subscription" do
+    variables = {
+      name: "Standard Plan",
+      returnUrl: "https://example.com/returnUrl",
+      lineItems: [{
+        plan: {
+          appRecurringPricingDetails: {
+            price: { amount: 29.99, currencyCode: "USD" },
+            interval: "ANNUAL"
+          }
+        }
+      }],
+      trialDays: 3,
+      test: true
+    }
+    fake(
+      "mutations/create_recurring_subscription.json",
+      ShopifyGraphql::CreateRecurringSubscription::MUTATION,
+      **variables
+    )
+
+    response = ShopifyGraphql::CreateRecurringSubscription.call(
+      name: "Standard Plan",
+      price: 29.99,
+      return_url: "https://example.com/returnUrl",
+      trial_days: 3,
+      test: true,
+      interval: :annual
+    )
+    subscription = response.data.subscription
+
+    assert_not_nil subscription.id
+    assert_equal "Standard Plan", subscription.name
+    assert_equal "PENDING", subscription.status
+    assert_kind_of Time, subscription.created_at
+    assert_equal 3, subscription.trial_days
+    assert subscription.test
+    assert_equal 29.99, subscription.recurring_price
+    assert_equal "ANNUAL", subscription.recurring_interval
+    assert_match %r{/admin/charges/(\d+)/(\d+)/RecurringApplicationCharge/confirm_recurring_application_charge}, response.data.confirmation_url
+  end
+end

--- a/test/graphql/shopify_graphql/create_usage_subscription_test.rb
+++ b/test/graphql/shopify_graphql/create_usage_subscription_test.rb
@@ -1,0 +1,45 @@
+require "test_helper"
+
+class CreateUsageSubscriptionTest < ActiveSupport::TestCase
+  test "creates subscription" do
+    variables = {
+      name: "Standard Plan",
+      returnUrl: "https://example.com/returnUrl",
+      test: true,
+      lineItems: [{
+        plan: {
+          appUsagePricingDetails: {
+            terms: "Terms Description",
+            cappedAmount: {amount: 50, currencyCode: "USD"}
+          }
+        }
+      }]
+    }
+    fake(
+      "mutations/create_usage_subscription.json",
+      ShopifyGraphql::CreateUsageSubscription::MUTATION,
+      **variables
+    )
+
+    response = ShopifyGraphql::CreateUsageSubscription.call(
+      name: "Standard Plan",
+      return_url: "https://example.com/returnUrl",
+      test: true,
+      terms: "Terms Description",
+      capped_amount: 50
+    )
+    subscription = response.data.subscription
+
+    assert_not_nil subscription.id
+    assert_equal "Standard Plan", subscription.name
+    assert_equal "PENDING", subscription.status
+    assert_equal 0, subscription.trial_days
+    assert_nil subscription.current_period_end
+    assert subscription.test
+    assert_equal 0.0, subscription.usage_balance
+    assert_equal 50.0, subscription.usage_capped_amount
+    assert_equal "EVERY_30_DAYS", subscription.usage_interval
+    assert_equal "Terms Description", subscription.usage_terms
+    assert_match %r{/admin/charges/(\d+)/(\d+)/RecurringApplicationCharge/confirm_recurring_application_charge}, response.data.confirmation_url
+  end
+end

--- a/test/graphql/shopify_graphql/get_app_subscription_test.rb
+++ b/test/graphql/shopify_graphql/get_app_subscription_test.rb
@@ -1,0 +1,19 @@
+require "test_helper"
+
+class GetAppSubscriptionTest < ActiveSupport::TestCase
+  test "returns subscription" do
+    app_subscription_gid = "gid://shopify/AppSubscription/22229811283"
+    fake("queries/app_subscription.json", ShopifyGraphql::GetAppSubscription::QUERY, id: app_subscription_gid)
+
+    response = ShopifyGraphql::GetAppSubscription.call(id: app_subscription_gid)
+    subscription = response.data
+
+    assert_equal "Standard Plan", subscription.name
+    assert_equal "PENDING", subscription.status
+    assert_kind_of Time, subscription.created_at
+    assert_equal 3, subscription.trial_days
+    assert subscription.test
+    assert_equal 29.99, subscription.recurring_price
+    assert_equal "ANNUAL", subscription.recurring_interval
+  end
+end

--- a/test/mutations_test.rb
+++ b/test/mutations_test.rb
@@ -17,7 +17,8 @@ class MutationsTest < ActiveSupport::TestCase
 
     response = ShopifyGraphql.execute(SIMPLE_MUTATION)
     product = response.data.productDuplicate.newProduct
-    assert_equal "gid://shopify/Product/6708088832083", product.id
+
+    assert_not_nil product.id
     assert_equal "Test product duplicate", product.title
   end
 end

--- a/test/queries_test.rb
+++ b/test/queries_test.rb
@@ -11,7 +11,7 @@ class QueriesTest < ActiveSupport::TestCase
     }
   GRAPHQL
 
-  QUERY_WITH_PARAMS = <<~GRAPHQL
+  QUERY_WITH_VARIABLES = <<~GRAPHQL
     query($id: ID!) {
       product(id: $id) {
         title
@@ -25,15 +25,17 @@ class QueriesTest < ActiveSupport::TestCase
 
     response = ShopifyGraphql.execute(SIMPLE_QUERY)
     shop = response.data.shop
+
     assert_equal "Graphql Gem Test", shop.name
   end
 
   test "query with params" do
     product_gid = "gid://shopify/Product/6708081623123"
-    fake("queries/product.json", QUERY_WITH_PARAMS, id: product_gid)
+    fake("queries/product.json", QUERY_WITH_VARIABLES, id: product_gid)
 
-    response = ShopifyGraphql.execute(QUERY_WITH_PARAMS, id: product_gid)
+    response = ShopifyGraphql.execute(QUERY_WITH_VARIABLES, id: product_gid)
     product = response.data.product
+
     assert_equal "Test product", product.title
     assert_equal "DRAFT", product.status
   end


### PR DESCRIPTION
Adds basic queries and mutations for AppSubscription management.

### Usage examples

Get app subscription:
```rb
subscription = ShopifyGraphql::GetAppSubscription.call(id: "gid://shopify/AppSubscription/123").data
subscription.name
# => Standard Plan
```

Create recurring subscription:
```rb
response = ShopifyGraphql::CreateRecurringSubscription.call(
  name: "Standard Plan",
  price: 29.99,
  return_url: "https://example.com/returnUrl",
  trial_days: 3,
  test: true,
  interval: :annual
).data
response.confirmation_url
# => https://test-shop.myshopify.com/admin/charges/...
```

Create usage subscription:
```rb
response = ShopifyGraphql::CreateUsageSubscription.call(
  name: "Standard Plan",
  return_url: "https://example.com/returnUrl",
  test: true,
  terms: "Terms Description",
  capped_amount: 50
).data
response.confirmation_url
# => https://test-shop.myshopify.com/admin/charges/...
```

### TODO
- [x] Add tests