### PR TITLE
Adds Ruby 3.2 to the CI matrix.  Also updates the checkout action version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,10 +5,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.7', '3.0', '3.1']
+        ruby-version: ['2.7', '3.0', '3.1', '3.2']
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,8 +90,8 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    date (3.3.1)
-    erubi (1.11.0)
+    date (3.3.3)
+    erubi (1.12.0)
     globalid (1.0.0)
       activesupport (>= 5.0)
     hash_diff (1.1.1)
@@ -101,8 +101,8 @@ GEM
       multi_xml (>= 0.5.2)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
-    jwt (2.5.0)
-    loofah (2.19.0)
+    jwt (2.6.0)
+    loofah (2.19.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.8.0)
@@ -118,7 +118,7 @@ GEM
     mini_mime (1.1.2)
     minitest (5.16.3)
     multi_xml (0.6.0)
-    net-imap (0.3.2)
+    net-imap (0.3.4)
       date
       net-protocol
     net-pop (0.1.2)
@@ -128,14 +128,16 @@ GEM
     net-smtp (0.3.3)
       net-protocol
     nio4r (2.5.8)
-    nokogiri (1.13.10-arm64-darwin)
+    nokogiri (1.14.0-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.13.10-x86_64-linux)
+    nokogiri (1.14.0-x86_64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.14.0-x86_64-linux)
       racc (~> 1.4)
     oj (3.13.23)
-    openssl (3.0.1)
+    openssl (3.1.0)
     public_suffix (5.0.1)
-    racc (1.6.1)
+    racc (1.6.2)
     rack (2.2.4)
     rack-test (2.0.2)
       rack (>= 1.3)
@@ -156,8 +158,8 @@ GEM
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
-    rails-html-sanitizer (1.4.3)
-      loofah (~> 2.3)
+    rails-html-sanitizer (1.4.4)
+      loofah (~> 2.19, >= 2.19.1)
     railties (7.0.4)
       actionpack (= 7.0.4)
       activesupport (= 7.0.4)
@@ -169,7 +171,7 @@ GEM
     redirect_safely (1.0.0)
       activemodel
     rexml (3.2.5)
-    securerandom (0.2.1)
+    securerandom (0.2.2)
     shopify_api (12.3.0)
       activesupport
       concurrent-ruby
@@ -181,7 +183,7 @@ GEM
       securerandom
       sorbet-runtime
       zeitwerk (~> 2.5, < 2.6.5)
-    shopify_app (21.3.0)
+    shopify_app (21.3.1)
       activeresource
       browser_sniffer (~> 2.0)
       jwt (>= 2.2.3)
@@ -189,16 +191,17 @@ GEM
       redirect_safely (~> 1.0)
       shopify_api (~> 12.3)
       sprockets-rails (>= 2.0.0)
-    sorbet-runtime (0.5.10588)
-    sprockets (4.1.1)
+    sorbet-runtime (0.5.10598)
+    sprockets (4.2.0)
       concurrent-ruby (~> 1.0)
-      rack (> 1, < 3)
+      rack (>= 2.2.4, < 4)
     sprockets-rails (3.4.2)
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
-    sqlite3 (1.5.4-arm64-darwin)
-    sqlite3 (1.5.4-x86_64-linux)
+    sqlite3 (1.6.0-arm64-darwin)
+    sqlite3 (1.6.0-x86_64-darwin)
+    sqlite3 (1.6.0-x86_64-linux)
     thor (1.2.1)
     timeout (0.3.1)
     tzinfo (2.0.5)
@@ -214,6 +217,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-22
+  x86_64-darwin-22
   x86_64-linux
 
 DEPENDENCIES
@@ -223,4 +227,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   2.3.26
+   2.4.3


### PR DESCRIPTION
To get this running green and without warnings I ran `bundle update`, specifically to pick up the nokogiri, sqlite3, and bundler updates.