### PR TITLE
Update API Session call to work with ShopifyAPI 10+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 /test/dummy/tmp/
 .byebug_history
 *.gem
+.idea/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -213,6 +213,7 @@ GEM
     zeitwerk (2.6.4)
 
 PLATFORMS
+  arm64-darwin-21
   arm64-darwin-22
   x86_64-linux
 

--- a/lib/shopify_graphql/jobs/create_webhooks_job.rb
+++ b/lib/shopify_graphql/jobs/create_webhooks_job.rb
@@ -5,10 +5,9 @@ module ShopifyGraphql
     end
 
     def perform(shop_domain:, shop_token:)
-      api_version = ShopifyApp.configuration.api_version
       webhooks = ShopifyGraphql.configuration.webhooks
 
-      ShopifyAPI::Session.temp(domain: shop_domain, token: shop_token, api_version: api_version) do
+      ShopifyAPI::Auth::Session.temp(shop: shop_domain, access_token: shop_token) do
         manager = WebhooksManager.new(webhooks)
         manager.create_webhooks
       end

--- a/lib/shopify_graphql/jobs/destroy_webhooks_job.rb
+++ b/lib/shopify_graphql/jobs/destroy_webhooks_job.rb
@@ -5,10 +5,9 @@ module ShopifyGraphql
     end
 
     def perform(shop_domain:, shop_token:)
-      api_version = ShopifyApp.configuration.api_version
       webhooks = ShopifyGraphql.configuration.webhooks
 
-      ShopifyAPI::Session.temp(domain: shop_domain, token: shop_token, api_version: api_version) do
+      ShopifyAPI::Auth::Session.temp(shop: shop_domain, access_token: shop_token) do
         manager = WebhooksManager.new(webhooks)
         manager.destroy_webhooks
       end

--- a/lib/shopify_graphql/jobs/update_webhooks_job.rb
+++ b/lib/shopify_graphql/jobs/update_webhooks_job.rb
@@ -5,10 +5,9 @@ module ShopifyGraphql
     end
 
     def perform(shop_domain:, shop_token:)
-      api_version = ShopifyApp.configuration.api_version
       webhooks = ShopifyGraphql.configuration.webhooks
 
-      ShopifyAPI::Session.temp(domain: shop_domain, token: shop_token, api_version: api_version) do
+      ShopifyAPI::Auth::Session.temp(shop: shop_domain, access_token: shop_token) do
         manager = WebhooksManager.new(webhooks)
         manager.recreate_webhooks!
       end


### PR DESCRIPTION
Updated API session calls to work with ShopifyAPI 10+. API Version can no longer be passed as a parameter