### PR TITLE
Add built-in calls for bulk operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -682,6 +682,10 @@ ShopifyGraphql.handle_user_errors(response)
 - `ShopifyGraphql::GetAppSubscription`
 - `ShopifyGraphql::UpsertPrivateMetafield`
 - `ShopifyGraphql::DeletePrivateMetafield`
+- `ShopifyGraphql::CreateBulkMutation`
+- `ShopifyGraphql::CreateBulkQuery`
+- `ShopifyGraphql::CreateStagedUploads`
+- `ShopifyGraphql::GetBulkOperation`
 
 Built-in wrappers are located in [`app/graphql/shopify_graphql`](/app/graphql/shopify_graphql/) folder. You can use them directly in your apps or as an example to create your own wrappers.
 

--- a/app/graphql/shopify_graphql/create_bulk_mutation.rb
+++ b/app/graphql/shopify_graphql/create_bulk_mutation.rb
@@ -1,0 +1,27 @@
+module ShopifyGraphql
+  class CreateBulkMutation
+    include Mutation
+
+    MUTATION = <<~GRAPHQL
+      mutation($mutation: String!, $stagedUploadPath: String!) {
+        bulkOperationRunMutation(mutation: $mutation, stagedUploadPath: $stagedUploadPath) {
+          bulkOperation {
+            id
+            status
+          }
+          userErrors {
+            field
+            message
+          }
+        }
+      }
+    GRAPHQL
+
+    def call(mutation:, staged_upload_path:)
+      response = execute(MUTATION, mutation: mutation, stagedUploadPath: staged_upload_path)
+      response.data = response.data.bulkOperationRunMutation
+      handle_user_errors(response.data)
+      response
+    end
+  end
+end

--- a/app/graphql/shopify_graphql/create_bulk_query.rb
+++ b/app/graphql/shopify_graphql/create_bulk_query.rb
@@ -1,0 +1,27 @@
+module ShopifyGraphql
+  class CreateBulkQuery
+    include Mutation
+
+    MUTATION = <<~GRAPHQL
+      mutation($query: String!) {
+        bulkOperationRunQuery(query: $query) {
+          bulkOperation {
+            id
+            status
+          }
+          userErrors {
+            field
+            message
+          }
+        }
+      }
+    GRAPHQL
+
+    def call(query:)
+      response = execute(MUTATION, query: query)
+      response.data = response.data.bulkOperationRunQuery
+      handle_user_errors(response.data)
+      response
+    end
+  end
+end

--- a/app/graphql/shopify_graphql/create_staged_uploads.rb
+++ b/app/graphql/shopify_graphql/create_staged_uploads.rb
@@ -1,0 +1,31 @@
+module ShopifyGraphql
+  class CreateStagedUploads
+    include Mutation
+
+    MUTATION = <<~GRAPHQL
+      mutation stagedUploadsCreate($input: [StagedUploadInput!]!) {
+        stagedUploadsCreate(input: $input) {
+          stagedTargets {
+            url
+            resourceUrl
+            parameters {
+              name
+              value
+            }
+          }
+          userErrors{
+            field,
+            message
+          }
+        }
+      }
+    GRAPHQL
+
+    def call(input:)
+      response = execute(MUTATION, input: input)
+      response.data = response.data.stagedUploadsCreate
+      handle_user_errors(response.data)
+      response
+    end
+  end
+end

--- a/app/graphql/shopify_graphql/get_bulk_operation.rb
+++ b/app/graphql/shopify_graphql/get_bulk_operation.rb
@@ -1,0 +1,44 @@
+module ShopifyGraphql
+  class GetBulkOperation
+    include Query
+
+    QUERY = <<~GRAPHQL
+      query($id: ID!){
+        node(id: $id) {
+          ... on BulkOperation {
+            id
+            status
+            errorCode
+            createdAt
+            completedAt
+            fileSize
+            url
+          }
+        }
+      }
+    GRAPHQL
+
+    def call(id:)
+      response = execute(QUERY, id: id)
+      response.data = parse_data(response.data.node)
+      response
+    end
+
+    private
+
+    def parse_data(data)
+      unless data
+        raise ResourceNotFound.new, "BulkOperation not found"
+      end
+
+      OpenStruct.new(
+        id: data.id,
+        status: data.status,
+        error_code: data.errorCode,
+        created_at: Time.find_zone("UTC").parse(data.createdAt),
+        completed_at: data.completedAt ? Time.find_zone("UTC").parse(data.completedAt) : nil,
+        url: data.url
+      )
+    end
+  end
+end


### PR DESCRIPTION
Added new build-in API calls:
- `ShopifyGraphql::CreateBulkMutation`
- `ShopifyGraphql::CreateBulkQuery`
- `ShopifyGraphql::CreateStagedUploads`
- `ShopifyGraphql::GetBulkOperation`