### PR TITLE
Add CurrentShop call

### DIFF
--- a/README.md
+++ b/README.md
@@ -676,6 +676,23 @@ ShopifyGraphql.handle_user_errors(response)
 
 ## Built-in Graphql calls
 
+- `ShopifyGraphql::CurrentShop`:
+
+  Equivalent to `ShopifyAPI::Shop.current`. Usage example:
+
+  ```rb
+  shop = ShopifyGraphql::CurrentShop.call
+  puts shop.name
+  ```
+
+  Or with locales (requires `read_locales` scope):
+
+  ```rb
+  shop = ShopifyGraphql::CurrentShop.call(with_locales: true)
+  puts shop.primary_locale
+  puts shop.shop_locales
+  ```
+
 - `ShopifyGraphql::CancelSubscription`
 - `ShopifyGraphql::CreateRecurringSubscription`
 - `ShopifyGraphql::CreateUsageSubscription`

--- a/app/graphql/shopify_graphql/current_shop.rb
+++ b/app/graphql/shopify_graphql/current_shop.rb
@@ -1,0 +1,123 @@
+module ShopifyGraphql
+  class CurrentShop
+    include ShopifyGraphql::Query
+
+    QUERY = <<~GRAPHQL
+      query {
+        shop {
+          id
+          name
+          email
+          contactEmail
+          myshopifyDomain
+          primaryDomain {
+            host
+          }
+          createdAt
+          updatedAt
+          #SHOP_OWNER_NAME#
+          currencyCode
+          billingAddress {
+            country
+            countryCodeV2
+            province
+            city
+            address1
+            address2
+            zip
+            latitude
+            longitude
+            phone
+          }
+          timezoneAbbreviation
+          ianaTimezone
+          plan {
+            displayName
+          }
+          currencyFormats {
+            moneyFormat
+            moneyInEmailsFormat
+            moneyWithCurrencyFormat
+            moneyWithCurrencyInEmailsFormat
+          }
+          weightUnit
+          taxShipping
+          taxesIncluded
+          setupRequired
+          checkoutApiSupported
+          transactionalSmsDisabled
+          enabledPresentmentCurrencies
+          marketingSmsConsentEnabledAtCheckout
+        }
+        #LOCALES_SUBQUERY#
+      }
+    GRAPHQL
+    LOCALES_SUBQUERY = <<~GRAPHQL
+      shopLocales {
+        locale
+        primary
+      }
+    GRAPHQL
+
+    def call(with_locales: false)
+      query = QUERY
+      query.gsub!("#LOCALES_SUBQUERY#", with_locales ? LOCALES_SUBQUERY : "")
+      if ShopifyAPI::Context.api_version.in?(%w[2024-01 2024-04 2024-07])
+        query.gsub!("#SHOP_OWNER_NAME#", "")
+      else
+        query.gsub!("#SHOP_OWNER_NAME#", "shopOwnerName")
+      end
+      response = execute(query)
+      parse_data(response.data, with_locales: with_locales)
+    end
+
+    private
+
+    def parse_data(data, with_locales: false)
+      response = OpenStruct.new(
+        id: data.shop.id,
+        name: data.shop.name,
+        email: data.shop.email,
+        customer_email: data.shop.contactEmail,
+        myshopify_domain: data.shop.myshopifyDomain,
+        domain: data.shop.primaryDomain.host,
+        created_at: data.shop.createdAt,
+        updated_at: data.shop.updatedAt,
+        shop_owner: data.shop.shopOwnerName,
+        currency: data.shop.currencyCode,
+        country_name: data.shop.billingAddress.country,
+        country: data.shop.billingAddress.countryCodeV2,
+        country_code: data.shop.billingAddress.countryCodeV2,
+        province: data.shop.billingAddress.province,
+        province_code: data.shop.billingAddress.provinceCode,
+        city: data.shop.billingAddress.city,
+        address1: data.shop.billingAddress.address1,
+        address2: data.shop.billingAddress.address2,
+        zip: data.shop.billingAddress.zip,
+        latitude: data.shop.billingAddress.latitude,
+        longitude: data.shop.billingAddress.longitude,
+        phone: data.shop.billingAddress.phone,
+        timezone: data.shop.timezoneAbbreviation,
+        iana_timezone: data.shop.ianaTimezone,
+        shopify_plan_name: data.shop.plan.displayName,
+        money_format: data.shop.currencyFormats.moneyFormat,
+        money_in_emails_format: data.shop.currencyFormats.moneyInEmailsFormat,
+        money_with_currency_format: data.shop.currencyFormats.moneyWithCurrencyFormat,
+        money_with_currency_in_emails_format: data.shop.currencyFormats.moneyWithCurrencyInEmailsFormat,
+        weight_unit: data.shop.weightUnit,
+        tax_shipping: data.shop.taxShipping,
+        taxes_included: data.shop.taxesIncluded,
+        setup_required: data.shop.setupRequired,
+        checkout_api_supported: data.shop.checkoutApiSupported,
+        transactional_sms_disabled: data.shop.transactionalSmsDisabled,
+        enabled_presentment_currencies: data.shop.enabledPresentmentCurrencies,
+        marketing_sms_consent_enabled_at_checkout: data.shop.marketingSmsConsentEnabledAtCheckout
+      )
+      if with_locales
+        response.primary_locale = data.shopLocales.find(&:primary).locale
+        response.shop_locales = data.shopLocales.map(&:locale)
+      end
+      response
+    end
+  end
+end

--- a/test/fixtures/queries/current_shop.json
+++ b/test/fixtures/queries/current_shop.json
@@ -1,0 +1,84 @@
+{
+  "data": {
+    "shop": {
+      "id": "gid://shopify/Shop/123",
+      "name": "Example Shop",
+      "email": "user@example.com",
+      "contactEmail": "user@example.com",
+      "myshopifyDomain": "example.myshopify.com",
+      "primaryDomain": {
+        "host": "example-shop.myshopify.com"
+      },
+      "createdAt": "2023-02-18T08:52:34Z",
+      "updatedAt": "2024-10-16T09:02:20Z",
+      "shopOwnerName": "Example User",
+      "currencyCode": "USD",
+      "billingAddress": {
+        "country": "United States",
+        "countryCodeV2": "US",
+        "province": null,
+        "city": null,
+        "address1": null,
+        "address2": "",
+        "zip": null,
+        "latitude": null,
+        "longitude": null,
+        "phone": null
+      },
+      "timezoneAbbreviation": "EDT",
+      "ianaTimezone": "America/New_York",
+      "plan": {
+        "displayName": "Developer Preview"
+      },
+      "taxesIncluded": false,
+      "currencyFormats": {
+        "moneyFormat": "${{amount}}",
+        "moneyInEmailsFormat": "${{amount}}",
+        "moneyWithCurrencyFormat": "${{amount}} USD",
+        "moneyWithCurrencyInEmailsFormat": "${{amount}} USD"
+      },
+      "weightUnit": "POUNDS",
+      "taxShipping": false,
+      "setupRequired": false,
+      "checkoutApiSupported": true,
+      "transactionalSmsDisabled": false,
+      "enabledPresentmentCurrencies": [
+        "AED",
+        "DKK",
+        "DZD",
+        "EUR",
+        "GBP",
+        "HUF",
+        "QAR",
+        "SHP",
+        "USD"
+      ],
+      "marketingSmsConsentEnabledAtCheckout": false
+    },
+    "shopLocales": [
+      {
+        "locale": "da",
+        "primary": false
+      },
+      {
+        "locale": "en",
+        "primary": true
+      },
+      {
+        "locale": "es",
+        "primary": false
+      }
+    ]
+  },
+  "extensions": {
+    "cost": {
+      "requestedQueryCost": 3,
+      "actualQueryCost": 3,
+      "throttleStatus": {
+        "maximumAvailable": 2000,
+        "currentlyAvailable": 1997,
+        "restoreRate": 100
+      }
+    }
+  }
+}

--- a/test/graphql/shopify_graphql/current_shop_test.rb
+++ b/test/graphql/shopify_graphql/current_shop_test.rb
@@ -1,0 +1,22 @@
+require "test_helper"
+
+class CurrentShopTest < ActiveSupport::TestCase
+  test "returns shop" do
+    fake("queries/current_shop.json", ShopifyGraphql::CurrentShop::QUERY)
+
+    shop = ShopifyGraphql::CurrentShop.call
+
+    assert_equal "Example Shop", shop.name
+    assert_equal "user@example.com", shop.email
+    assert_equal "example.myshopify.com", shop.myshopify_domain
+  end
+
+  test "returns shop with shop locales" do
+    fake("queries/current_shop.json", ShopifyGraphql::CurrentShop::QUERY)
+
+    shop = ShopifyGraphql::CurrentShop.call(with_locales: true)
+
+    assert_equal "en", shop.primary_locale
+    assert_equal ["da", "en", "es"], shop.shop_locales
+  end
+end


### PR DESCRIPTION
Replacement for `ShopifyAPI::Shop.current` in REST API. Usage:

```rb
shop = ShopifyGraphql::CurrentShop.call
shop.name

# or with locales (requires `read_locales` scope)
shop = ShopifyGraphql::CurrentShop.call(with_locales: true)
shop.primary_locale # => "en"
shop.shop_locales # => ["da", "en", "es"]
```