### PR TITLE
Normalize `plan_display_name`, add plans mappings and fallback for `plan_name`

### DIFF
--- a/app/graphql/shopify_graphql/current_shop.rb
+++ b/app/graphql/shopify_graphql/current_shop.rb
@@ -74,6 +74,8 @@ module ShopifyGraphql
     private
 
     def parse_data(data, with_locales: false)
+      plan_display_name = ShopifyGraphql.normalize_display_plan(data.shop.plan.displayName)
+      plan_name = ShopifyGraphql::DISPLAY_NAME_TO_PLAN[plan_display_name]
       response = OpenStruct.new(
         id: data.shop.id,
         name: data.shop.name,
@@ -99,7 +101,8 @@ module ShopifyGraphql
         phone: data.shop.billingAddress.phone,
         timezone: data.shop.timezoneAbbreviation,
         iana_timezone: data.shop.ianaTimezone,
-        shopify_plan_name: data.shop.plan.displayName,
+        plan_name: plan_name,
+        plan_display_name: plan_display_name,
         money_format: data.shop.currencyFormats.moneyFormat,
         money_in_emails_format: data.shop.currencyFormats.moneyInEmailsFormat,
         money_with_currency_format: data.shop.currencyFormats.moneyWithCurrencyFormat,

--- a/lib/shopify_graphql/client.rb
+++ b/lib/shopify_graphql/client.rb
@@ -1,4 +1,29 @@
 module ShopifyGraphql
+  # Mapping from deprecated plan_name to plan_display_name
+  PLAN_TO_DISPLAY_NAME = {
+    "trial" => "trial",
+    "frozen" => "frozen",
+    "fraudulent" => "cancelled",
+    "shopify_alumni" =>	"shopify_alumni",
+    "affiliate" => "development",
+    "basic" => "basic",
+    "professional" => "shopify",
+    "npo_full" => "npo_full",
+    "shopify_plus" => "shopify_plus",
+    "staff" => "staff",
+    "unlimited" => "advanced",
+    "retail" => "retail",
+    "cancelled" => "cancelled",
+    "dormant" => "pause_and_build",
+    "starter_2022" => "shopify_starter",
+    "plus_partner_sandbox" => "shopify_plus_partner_sandbox",
+    "paid_trial" => "extended_trial",
+    "partner_test" => "developer_preview",
+    "open_learning" => "open_learning",
+    "staff_business" => "staff_business"
+  }
+  DISPLAY_NAME_TO_PLAN = PLAN_TO_DISPLAY_NAME.invert
+
   class Client
     def client
       @client ||= ShopifyAPI::Clients::Graphql::Admin.new(session: ShopifyAPI::Context.active_session)
@@ -123,6 +148,11 @@ module ShopifyGraphql
 
     def client
       Client.new
+    end
+
+    def normalize_display_plan(plan_display_name)
+      return if plan_display_name.blank?
+      plan_display_name.parameterize(separator: "_")
     end
   end
 end

--- a/test/graphql/shopify_graphql/current_shop_test.rb
+++ b/test/graphql/shopify_graphql/current_shop_test.rb
@@ -19,4 +19,13 @@ class CurrentShopTest < ActiveSupport::TestCase
     assert_equal "en", shop.primary_locale
     assert_equal ["da", "en", "es"], shop.shop_locales
   end
+
+  test "plan normalization and fallback" do
+    fake("queries/current_shop.json", ShopifyGraphql::CurrentShop::QUERY)
+
+    shop = ShopifyGraphql::CurrentShop.call
+
+    assert_equal "developer_preview", shop.plan_display_name # normalized
+    assert_equal "partner_test", shop.plan_name # mapped fallback
+  end
 end


### PR DESCRIPTION
- Plan display name field normalized to always return lowercase underscore value (eg `pause_and_build` instead of `Pause and Build`).
- Added mappings between old plans in REST and new plans in Graphql: `ShopifyGraphql::PLAN_TO_DISPLAY_NAME` and `ShopifyGraphql::DISPLAY_NAME_TO_PLAN`. They can be used to generate new plan name from old one and vice-versa.
> I used values for this mapping based on my app DBs. If you'll notice that some plan names are missing, please open a PR.
- Added fallback for `plan_name` which was removed in Graphql API, but we still can get it's value using mapping. This should make migration to Graphql easier.