### PR TITLE
Move text error codes to #error_code field

### DIFF
--- a/lib/shopify_graphql/exceptions.rb
+++ b/lib/shopify_graphql/exceptions.rb
@@ -1,5 +1,7 @@
 module ShopifyGraphql
   class ConnectionError < ShopifyAPI::Errors::HttpResponseError
+    attr_accessor :error_code, :fields
+
     def initialize(response: nil)
       unless response
         empty_response = ShopifyAPI::Clients::HttpResponse.new(code: 200, headers: {}, body: "")
@@ -72,14 +74,6 @@ module ShopifyGraphql
   end
 
   # Custom error for Graphql userErrors handling
-  class UserError < StandardError
-    attr_reader :response, :message, :code, :fields
-
-    def initialize(response:, message:, code:, fields:)
-      @response = response
-      @message = message
-      @code = code
-      @fields = fields
-    end
+  class UserError < ConnectionError
   end
 end

--- a/test/error_handling_test.rb
+++ b/test/error_handling_test.rb
@@ -42,7 +42,22 @@ class ErrorHandlingTest < ActiveSupport::TestCase
       response = ShopifyGraphql.execute(SIMPLE_QUERY)
       ShopifyGraphql::Client.new.handle_user_errors(response.data.metafieldDefinitionCreate)
     rescue ShopifyGraphql::UserError => error
-      assert_equal "TAKEN", error.code
+      assert_equal 200, error.code
+      assert_equal "TAKEN", error.error_code
+      assert_includes error.message, "Key is in use for Product metafields"
+      assert_equal ["definition", "key"], error.fields
+    end
+  end
+
+  test "server error" do
+    fake("mutations/server_error.json", SIMPLE_QUERY)
+
+    begin
+      ShopifyGraphql.execute(SIMPLE_QUERY)
+    rescue ShopifyGraphql::ServerError => error
+      assert_equal 200, error.code
+      assert_equal "INTERNAL_SERVER_ERROR", error.error_code
+      assert_includes error.message, "Looks like something went wrong on our end"
     end
   end
 end

--- a/test/fixtures/mutations/server_error.json
+++ b/test/fixtures/mutations/server_error.json
@@ -1,0 +1,11 @@
+{
+  "errors": [
+    {
+      "message": "Internal error. Looks like something went wrong on our end.\nRequest ID: XXXXX (include this in support requests).",
+      "extensions": {
+        "code": "INTERNAL_SERVER_ERROR",
+        "requestId": "XXXXX"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Error's #code field now returns server response code, similar to `shopify_api` gem. Text error code has been moved to separate field #error_code.

Example:
```rb
begin
  ShopifyGraphql.execute(SIMPLE_QUERY)
rescue ShopifyGraphql::ServerError => error
  assert_equal 200, error.code
  assert_equal "INTERNAL_SERVER_ERROR", error.error_code
end
```