### PR TITLE
Add support for custom headers in GraphQL client execute method

### DIFF
--- a/lib/shopify_graphql/client.rb
+++ b/lib/shopify_graphql/client.rb
@@ -29,8 +29,8 @@ module ShopifyGraphql
       @client ||= ShopifyAPI::Clients::Graphql::Admin.new(session: ShopifyAPI::Context.active_session)
     end
 
-    def execute(query, **variables)
-      response = client.query(query: query, variables: variables)
+    def execute(query, headers: nil, **variables)
+      response = client.query(query: query, variables: variables, headers: headers)
       Response.new(handle_response(response))
     rescue ShopifyAPI::Errors::HttpResponseError => e
       Response.new(handle_response(e.response, e))

--- a/test/queries_test.rb
+++ b/test/queries_test.rb
@@ -39,4 +39,21 @@ class QueriesTest < ActiveSupport::TestCase
     assert_equal "Test product", product.title
     assert_equal "DRAFT", product.status
   end
+
+  test "query with headers" do
+    custom_headers = { "X-Custom-Header" => "test-value" }
+    
+    stub_request(:post, API_PATH)
+      .with(
+        body: { query: SIMPLE_QUERY, variables: {} },
+        headers: custom_headers
+      )
+      .to_return(body: File.read(File.expand_path("fixtures/queries/shop.json", __dir__)))
+
+    response = ShopifyGraphql.execute(SIMPLE_QUERY, headers: custom_headers)
+    shop = response.data.shop
+
+    assert_equal "Graphql Gem Test", shop.name
+    assert_requested :post, API_PATH, headers: custom_headers
+  end
 end


### PR DESCRIPTION
This pull request includes changes to the `ShopifyGraphql` client and its corresponding test suite to support custom headers in GraphQL queries. The most important changes are:

Enhancements to GraphQL client:

* [`lib/shopify_graphql/client.rb`](diffhunk://#diff-b6e4b01c7e94cce2ffc327ebb3296cf3d3c99401be351f3904ec74c38f6f4c53L32-R33): Modified the `execute` method to accept an optional `headers` parameter and include it in the GraphQL query request.

Updates to test suite:

* [`test/queries_test.rb`](diffhunk://#diff-7b15038158534f1fe349e6e703a05b88ba2b390501f377ff5cc68fa01207c461R42-R58): Added a new test to verify that the `execute` method correctly handles custom headers in GraphQL queries.