### PR TITLE
Add count fields to get bulk operation query

### DIFF
--- a/app/graphql/shopify_graphql/get_bulk_operation.rb
+++ b/app/graphql/shopify_graphql/get_bulk_operation.rb
@@ -13,6 +13,8 @@ module ShopifyGraphql
             completedAt
             fileSize
             url
+            objectCount
+            rootObjectCount
           }
         }
       }
@@ -37,7 +39,9 @@ module ShopifyGraphql
         error_code: data.errorCode,
         created_at: Time.find_zone("UTC").parse(data.createdAt),
         completed_at: data.completedAt ? Time.find_zone("UTC").parse(data.completedAt) : nil,
-        url: data.url
+        url: data.url,
+        object_count: data.objectCount,
+        root_object_count: data.rootObjectCount,
       )
     end
   end


### PR DESCRIPTION
### What does this PR do?

Add `objectCount` and `rootObjectCount` fields to `BulkOperation` GraphQL query.