### PR TITLE
Add `code` field to bulk operation query

### DIFF
--- a/app/graphql/shopify_graphql/create_bulk_mutation.rb
+++ b/app/graphql/shopify_graphql/create_bulk_mutation.rb
@@ -10,6 +10,7 @@ module ShopifyGraphql
             status
           }
           userErrors {
+            code
             field
             message
           }

--- a/app/graphql/shopify_graphql/create_bulk_query.rb
+++ b/app/graphql/shopify_graphql/create_bulk_query.rb
@@ -10,6 +10,7 @@ module ShopifyGraphql
             status
           }
           userErrors {
+            code
             field
             message
           }


### PR DESCRIPTION
### Why PR introduced?

[Shopify Changelog - Bulk query operation userErrors now includes code field](https://shopify.dev/changelog/bulk-query-operation-usererrors-now-includes-code-field)

### What PR do?

Add `code` field to `BulkOperationUserError` in `bulkOperationRunMutation` and `bulkOperationRunQuery`.