### PR TITLE
Correctly handle multiple user errors

### DIFF
--- a/lib/shopify_graphql/exceptions.rb
+++ b/lib/shopify_graphql/exceptions.rb
@@ -1,6 +1,6 @@
 module ShopifyGraphql
   class ConnectionError < ShopifyAPI::Errors::HttpResponseError
-    attr_accessor :error_code, :fields
+    attr_accessor :error_codes, :fields, :messages
 
     def initialize(response: nil)
       unless response

--- a/lib/shopify_graphql/exceptions.rb
+++ b/lib/shopify_graphql/exceptions.rb
@@ -1,6 +1,6 @@
 module ShopifyGraphql
   class ConnectionError < ShopifyAPI::Errors::HttpResponseError
-    attr_accessor :error_codes, :fields, :messages
+    attr_accessor :error_code, :error_codes, :fields, :messages
 
     def initialize(response: nil)
       unless response

--- a/test/error_handling_test.rb
+++ b/test/error_handling_test.rb
@@ -43,9 +43,10 @@ class ErrorHandlingTest < ActiveSupport::TestCase
       ShopifyGraphql::Client.new.handle_user_errors(response.data.metafieldDefinitionCreate)
     rescue ShopifyGraphql::UserError => error
       assert_equal 200, error.code
-      assert_equal "TAKEN", error.error_code
+      assert error.error_codes.include?("TAKEN")
       assert_includes error.message, "Key is in use for Product metafields"
-      assert_equal ["definition", "key"], error.fields
+      assert_includes error.messages, "Key is in use for Product metafields on the 'xxx' namespace."
+      assert error.fields.include?(["definition", "key"])
     end
   end
 
@@ -56,8 +57,8 @@ class ErrorHandlingTest < ActiveSupport::TestCase
       ShopifyGraphql.execute(SIMPLE_QUERY)
     rescue ShopifyGraphql::ServerError => error
       assert_equal 200, error.code
-      assert_equal "INTERNAL_SERVER_ERROR", error.error_code
-      assert_includes error.message, "Looks like something went wrong on our end"
+      assert_equal ["INTERNAL_SERVER_ERROR"], error.error_codes
+      assert_includes error.messages, "Internal error. Looks like something went wrong on our end.\nRequest ID: XXXXX (include this in support requests)."
     end
   end
 

--- a/test/error_handling_test.rb
+++ b/test/error_handling_test.rb
@@ -43,12 +43,32 @@ class ErrorHandlingTest < ActiveSupport::TestCase
       ShopifyGraphql::Client.new.handle_user_errors(response.data.metafieldDefinitionCreate)
     rescue ShopifyGraphql::UserError => error
       assert_equal 200, error.code
+      assert_equal "TAKEN", error.error_code
       assert error.error_codes.include?("TAKEN")
       assert_includes error.message, "Key is in use for Product metafields"
       assert_includes error.messages, "Key is in use for Product metafields on the 'xxx' namespace."
       assert error.fields.include?(["definition", "key"])
     end
   end
+
+  test "multiple user errors" do
+    fake("mutations/multiple_user_errors.json", SIMPLE_QUERY)
+
+    begin
+      response = ShopifyGraphql.execute(SIMPLE_QUERY)
+      ShopifyGraphql::Client.new.handle_user_errors(response.data.metafieldsSet)
+    rescue ShopifyGraphql::UserError => error
+      assert_equal 200, error.code
+      assert_equal "INVALID_VALUE", error.error_code
+      assert error.error_codes.include?("INVALID_VALUE")
+      assert_equal error.error_codes, ["INVALID_VALUE", "INVALID_VALUE"]
+      assert_includes error.messages, "Value does not exist in provided choices: [\"Male\", \"Female\", \"Other\"]."
+      assert_includes error.message, "2 fields have failed"
+      assert_includes error.message, "Value has a maximum length of 10."
+      assert_equal error.fields, [["metafields", "0", "value"], ["metafields", "1", "value"]]
+    end
+  end
+
 
   test "server error" do
     fake("mutations/server_error.json", SIMPLE_QUERY)
@@ -57,6 +77,7 @@ class ErrorHandlingTest < ActiveSupport::TestCase
       ShopifyGraphql.execute(SIMPLE_QUERY)
     rescue ShopifyGraphql::ServerError => error
       assert_equal 200, error.code
+      assert_equal "INTERNAL_SERVER_ERROR", error.error_code
       assert_equal ["INTERNAL_SERVER_ERROR"], error.error_codes
       assert_includes error.messages, "Internal error. Looks like something went wrong on our end.\nRequest ID: XXXXX (include this in support requests)."
     end

--- a/test/fixtures/mutations/multiple_user_errors.json
+++ b/test/fixtures/mutations/multiple_user_errors.json
@@ -1,0 +1,38 @@
+{
+  "data": {
+    "metafieldsSet": {
+      "metafields": [],
+      "userErrors": [
+        {
+          "field": [
+            "metafields",
+            "0",
+            "value"
+          ],
+          "message": "Value does not exist in provided choices: [\"Male\", \"Female\", \"Other\"].",
+          "code": "INVALID_VALUE"
+        },
+        {
+          "field": [
+            "metafields",
+            "1",
+            "value"
+          ],
+          "message": "Value has a maximum length of 10.",
+          "code": "INVALID_VALUE"
+        }
+      ]
+    }
+  },
+  "extensions": {
+    "cost": {
+      "requestedQueryCost": 10,
+      "actualQueryCost": 10,
+      "throttleStatus": {
+        "maximumAvailable": 2000,
+        "currentlyAvailable": 1990,
+        "restoreRate": 100
+      }
+    }
+  }
+}


### PR DESCRIPTION
- closes #59 

This PR fixes how multiple user errors are managed.

`error.message` will return:

```
2 fields have failed:

- Response code = INVALID_VALUE. Response message = Value has a minimum length of 5. Field = ["metafields", "0", "value"].

- Response code = INVALID_VALUE. Response message = Value has a minimum length of 5. Field = ["metafields", "3", "value"].
```

`error.messages` will return:

```
["Value has a minimum length of 5.", "Value has a minimum of 11111."]
```

`error.fields` will return:

```
[["metafields", "0", "value"], ["metafields", "3", "value"]]
```

`error.error_codes` will return:

```
["INVALID_VALUE", "INVALID_VALUE"]
```