### PR TITLE
Add graphql_points_limit to CurrentShop

### DIFF
--- a/test/graphql/shopify_graphql/current_shop_test.rb
+++ b/test/graphql/shopify_graphql/current_shop_test.rb
@@ -12,6 +12,7 @@ class CurrentShopTest < ActiveSupport::TestCase
     assert_equal "example.myshopify.com", shop.myshopify_domain
     assert_equal 3, shop.max_product_options
     assert_equal 100, shop.max_product_variants
+    assert_equal 2000, shop.graphql_points_limit
   end
 
   test "returns shop with shop locales" do


### PR DESCRIPTION
In rare cases (lucky me!) Shopify might manually reduce rate limit for specific shop. To work with such limitations, it's useful to have rate limit information right in CurrentShop, to store it in DB and then use for dynamic rate limiting of API requests.

Example:
```rb
shop = ShopifyGraphql::CurrentShop.call
puts shop.graphql_points_limit
```