### PR TITLE
Add ShopPendingTermination error

### DIFF
--- a/lib/shopify_graphql/client.rb
+++ b/lib/shopify_graphql/client.rb
@@ -110,6 +110,8 @@ module ShopifyGraphql
           TooManyRequests.new(response: response)
         when "INTERNAL_SERVER_ERROR"
           ServerError.new(response: response)
+        when "SHOP_PENDING_TERMINATION"
+          ShopPendingTermination.new(response: response)
         else
           ConnectionError.new(response: response)
         end

--- a/lib/shopify_graphql/exceptions.rb
+++ b/lib/shopify_graphql/exceptions.rb
@@ -65,6 +65,10 @@ module ShopifyGraphql
   class ShopLocked < ClientError # :nodoc:
   end
 
+  # GraphQL SHOP_PENDING_TERMINATION error code (shop is under review)
+  class ShopPendingTermination < ClientError # :nodoc:
+  end
+
   # 429 Too Many Requests
   class TooManyRequests < ClientError # :nodoc:
   end

--- a/test/error_handling_test.rb
+++ b/test/error_handling_test.rb
@@ -83,6 +83,18 @@ class ErrorHandlingTest < ActiveSupport::TestCase
     end
   end
 
+  test "shop pending termination error" do
+    fake("mutations/shop_pending_termination.json", SIMPLE_QUERY)
+
+    error = assert_raises ShopifyGraphql::ShopPendingTermination do
+      ShopifyGraphql.execute(SIMPLE_QUERY)
+    end
+    assert_equal 200, error.code
+    assert_equal "SHOP_PENDING_TERMINATION", error.error_code
+    assert_equal ["SHOP_PENDING_TERMINATION"], error.error_codes
+    assert_includes error.message, "Shop is under review"
+  end
+
   test "handle http response error" do
     fake("error_page.html", SIMPLE_QUERY)
 

--- a/test/fixtures/mutations/shop_pending_termination.json
+++ b/test/fixtures/mutations/shop_pending_termination.json
@@ -1,0 +1,10 @@
+{
+  "errors": [
+    {
+      "message": "Access denied for products field. Shop is under review.",
+      "extensions": {
+        "code": "SHOP_PENDING_TERMINATION"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Map the GraphQL SHOP_PENDING_TERMINATION error code to a dedicated ShopPendingTermination exception instead of falling through to a generic ConnectionError.